### PR TITLE
COMPLEX-4: When complex 0 is rasied to a positive (real) exponent, return zero.

### DIFF
--- a/src/main/java/org/apache/commons/complex/Complex.java
+++ b/src/main/java/org/apache/commons/complex/Complex.java
@@ -864,6 +864,15 @@ public class Complex implements Serializable  {
      */
     public Complex pow(Complex x) {
         checkNotNull(x);
+        if (real == 0 && imaginary == 0) {
+            if (x.real > 0 && x.imaginary == 0) {
+                // 0 raised to positive number is 0
+                return ZERO;
+            } else {
+                // 0 raised to anything else is NaN
+                return NaN;
+            }
+        }
         return this.log().multiply(x).exp();
     }
 
@@ -875,6 +884,15 @@ public class Complex implements Serializable  {
      * @see #pow(Complex)
      */
      public Complex pow(double x) {
+        if (real == 0 && imaginary == 0) {
+            if (x > 0) {
+                // 0 raised to positive number is 0
+                return ZERO;
+            } else {
+                // 0 raised to anything else is NaN
+                return NaN;
+            }
+        }
         return this.log().multiply(x).exp();
     }
 

--- a/src/test/java/org/apache/commons/complex/ComplexTest.java
+++ b/src/test/java/org/apache/commons/complex/ComplexTest.java
@@ -936,8 +936,10 @@ public class ComplexTest {
 
    @Test
    public void testPowZero() {
-       TestUtils.assertSame(Complex.NaN,
-               Complex.ZERO.pow(Complex.ONE));
+       TestUtils.assertEquals(Complex.ZERO,
+              Complex.ZERO.pow(Complex.ONE), 10e-12);
+       TestUtils.assertEquals(Complex.ZERO,
+               Complex.ZERO.pow(new Complex(2, 0)), 10e-12);
        TestUtils.assertSame(Complex.NaN,
                Complex.ZERO.pow(Complex.ZERO));
        TestUtils.assertSame(Complex.NaN,
@@ -994,8 +996,10 @@ public class ComplexTest {
 
    @Test
    public void testScalarPowZero() {
-       TestUtils.assertSame(Complex.NaN, Complex.ZERO.pow(1.0));
+       TestUtils.assertEquals(Complex.ZERO, Complex.ZERO.pow(1.0), 10e-12);
+       TestUtils.assertEquals(Complex.ZERO, Complex.ZERO.pow(2.0), 10e-12);
        TestUtils.assertSame(Complex.NaN, Complex.ZERO.pow(0.0));
+       TestUtils.assertSame(Complex.NaN, Complex.ZERO.pow(-1.0));
        TestUtils.assertEquals(Complex.ONE, Complex.ONE.pow(0.0), 10e-12);
        TestUtils.assertEquals(Complex.ONE, Complex.I.pow(0.0), 10e-12);
        TestUtils.assertEquals(Complex.ONE, new Complex(-1, 3).pow(0.0), 10e-12);


### PR DESCRIPTION
Prior behavior returned NaN for any power of zero implicitly by calling log() with a zero argument. 